### PR TITLE
✏️Fix typo propsType -> propTypes.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -172,7 +172,7 @@ ReactFlagsSelect.defaultProps = {
 	searchable: false
 }
 
-ReactFlagsSelect.propsType = {
+ReactFlagsSelect.propTypes = {
 	countries: PropTypes.array,
 	blackList: PropTypes.bool,
 	customLabels: PropTypes.array,


### PR DESCRIPTION
- ✏️Fixed a typo in the main component file where `propTypes` was written as `propsType`.