### PR TITLE
Create an optional "showArrow" prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,30 +7,33 @@
 A customizable svg flags select components for React Js.
 
 ## Demo and Example
+
 Live demo: [ekwonye-richard.github.io/react-flags-select/](https://ekwonye-richard.github.io/react-flags-select/)
 
 ## Installation
+
 The package can be installed via NPM:
+
 ```
 npm install react-flags-select --save
 ```
+
 react-flags-select can be imported as follows
 
 ```javascript
-import ReactFlagsSelect from 'react-flags-select';
+import ReactFlagsSelect from "react-flags-select";
 
 //import css module
-import 'react-flags-select/css/react-flags-select.css';
+import "react-flags-select/css/react-flags-select.css";
 
 //OR import sass module
-import 'react-flags-select/scss/react-flags-select.scss';
-
+import "react-flags-select/scss/react-flags-select.scss";
 ```
 
 ## Usage
 
 ```javascript
-    <ReactFlagsSelect />
+<ReactFlagsSelect />
 ```
 
 All country Codes: [Country Codes](https://github.com/ekwonye-richard/react-flags-select/blob/master/src/countries.js)
@@ -40,8 +43,7 @@ All country Codes: [Country Codes](https://github.com/ekwonye-richard/react-flag
 You can select a default country to be rendered.
 
 ```javascript
-    <ReactFlagsSelect
-    defaultCountry="US" />
+<ReactFlagsSelect defaultCountry="US" />
 ```
 
 ### Searchable
@@ -49,8 +51,7 @@ You can select a default country to be rendered.
 You can enable search filter using prop `searchable`.
 
 ```javascript
-    <ReactFlagsSelect
-    searchable={true} />
+<ReactFlagsSelect searchable={true} />
 ```
 
 ### Search Placeholder
@@ -58,26 +59,24 @@ You can enable search filter using prop `searchable`.
 You can set the placeholder text for search using prop `searchPlaceholder`.
 
 ```javascript
-    <ReactFlagsSelect
-    searchable={true}
-    searchPlaceholder="Search for a country" />
+<ReactFlagsSelect searchable={true} searchPlaceholder="Search for a country" />
 ```
-
 
 ### Countries
 
 You can use an array of countries rather than the full list of countries.
 
 ```javascript
-    <ReactFlagsSelect
-    countries={["US", "GB", "FR", "DE", "IT", "NG"]} />
+<ReactFlagsSelect countries={["US", "GB", "FR", "DE", "IT", "NG"]} />
 ```
+
 or create a black list of countries
 
 ```javascript
-    <ReactFlagsSelect
-    countries={["US", "GB", "FR", "DE", "IT", "NG"]}
-    blackList={true} />
+<ReactFlagsSelect
+  countries={["US", "GB", "FR", "DE", "IT", "NG"]}
+  blackList={true}
+/>
 ```
 
 ### Custom Labels
@@ -85,9 +84,10 @@ or create a black list of countries
 You can use an object of countries labels to replace the countries name. The default country name for a country will be used when the country code has no label passed.
 
 ```javascript
-    <ReactFlagsSelect
-    countries={["US", "GB", "FR","DE","IT"]}
-    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}} />
+<ReactFlagsSelect
+  countries={["US", "GB", "FR", "DE", "IT"]}
+  customLabels={{ US: "EN-US", GB: "EN-GB", FR: "FR", DE: "DE", IT: "IT" }}
+/>
 ```
 
 ### Placeholder
@@ -95,10 +95,11 @@ You can use an object of countries labels to replace the countries name. The def
 You can replace the default placeholder text.
 
 ```javascript
-    <ReactFlagsSelect
-    countries={["US", "GB", "FR","DE","IT"]}
-    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
-    placeholder="Select Language" />
+<ReactFlagsSelect
+  countries={["US", "GB", "FR", "DE", "IT"]}
+  customLabels={{ US: "EN-US", GB: "EN-GB", FR: "FR", DE: "DE", IT: "IT" }}
+  placeholder="Select Language"
+/>
 ```
 
 ### Show Selected Label
@@ -106,11 +107,12 @@ You can replace the default placeholder text.
 You can hide or show the label of a selected flag. The default value is true.
 
 ```javascript
-    <ReactFlagsSelect
-    countries={["US", "GB", "FR","DE","IT"]}
-    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
-    placeholder="Select Language"
-    showSelectedLabel={false} />
+<ReactFlagsSelect
+  countries={["US", "GB", "FR", "DE", "IT"]}
+  customLabels={{ US: "EN-US", GB: "EN-GB", FR: "FR", DE: "DE", IT: "IT" }}
+  placeholder="Select Language"
+  showSelectedLabel={false}
+/>
 ```
 
 ### Show Option Label
@@ -118,12 +120,13 @@ You can hide or show the label of a selected flag. The default value is true.
 You can hide or show the label of the flags in the options dropdown. The default value is true.
 
 ```javascript
-    <ReactFlagsSelect
-    countries={["US", "GB", "FR","DE","IT"]}
-    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
-    placeholder="Select Language"
-    showSelectedLabel={false}
-    showOptionLabel={false} />
+<ReactFlagsSelect
+  countries={["US", "GB", "FR", "DE", "IT"]}
+  customLabels={{ US: "EN-US", GB: "EN-GB", FR: "FR", DE: "DE", IT: "IT" }}
+  placeholder="Select Language"
+  showSelectedLabel={false}
+  showOptionLabel={false}
+/>
 ```
 
 ### Selected Size
@@ -131,27 +134,30 @@ You can hide or show the label of the flags in the options dropdown. The default
 You can set the size in pixels for the svg flag and label of the selected option.
 
 ```javascript
-    <ReactFlagsSelect
-    countries={["US", "GB", "FR","DE","IT"]}
-    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
-    placeholder="Select Language"
-    showSelectedLabel={false}
-    showOptionLabel={false}
-    selectedSize={14} />
+<ReactFlagsSelect
+  countries={["US", "GB", "FR", "DE", "IT"]}
+  customLabels={{ US: "EN-US", GB: "EN-GB", FR: "FR", DE: "DE", IT: "IT" }}
+  placeholder="Select Language"
+  showSelectedLabel={false}
+  showOptionLabel={false}
+  selectedSize={14}
+/>
 ```
 
 ### Options Size
 
 You can set the size in pixels for the svg flags and labels in the options dropdown.
+
 ```javascript
-    <ReactFlagsSelect
-    countries={["US", "GB", "FR","DE","IT"]}
-    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
-    placeholder="Select Language"
-    showSelectedLabel={false}
-    showOptionLabel={false}
-    selectedSize={18}
-    optionsSize={14} />
+<ReactFlagsSelect
+  countries={["US", "GB", "FR", "DE", "IT"]}
+  customLabels={{ US: "EN-US", GB: "EN-GB", FR: "FR", DE: "DE", IT: "IT" }}
+  placeholder="Select Language"
+  showSelectedLabel={false}
+  showOptionLabel={false}
+  selectedSize={18}
+  optionsSize={14}
+/>
 ```
 
 ### className
@@ -159,17 +165,15 @@ You can set the size in pixels for the svg flags and labels in the options dropd
 You can pass a style className that will be attached to the top-level `div` of the component.
 
 ```javascript
-    <ReactFlagsSelect
-    className="menu-flags" />
+<ReactFlagsSelect className="menu-flags" />
 ```
 
 ### Align Options
 
-You can align the options dropdown to  either left or right. The default value is right.
+You can align the options dropdown to either left or right. The default value is right.
 
 ```javascript
-    <ReactFlagsSelect
-    alignOptions="left" />
+<ReactFlagsSelect alignOptions="left" />
 ```
 
 ### Disabled
@@ -177,10 +181,23 @@ You can align the options dropdown to  either left or right. The default value i
 You can disable the options dropdown, however the selected country can be updated using the `updateSelected()` method. This can be used for flag badges.
 
 ```javascript
-    <ReactFlagsSelect
-    defaultCountry="US"
-    showSelectedLabel={false}
-    disabled={true} />
+<ReactFlagsSelect
+  defaultCountry="US"
+  showSelectedLabel={false}
+  disabled={true}
+/>
+```
+
+### Show Arrow
+
+You can hide or show the down arrow. The default value is true.
+
+```javascript
+<ReactFlagsSelect
+  defaultCountry="US"
+  showSelectedLabel={false}
+  showArrow={false}
+/>
 ```
 
 ### onSelect
@@ -193,7 +210,7 @@ You can use onSelect event handler which fires each time an option is selected.
     onSelectFlag(countryCode){
         console.log(countryCode)
     }
-    
+
     //component render
     <ReactFlagsSelect
     defaultCountry="US"
@@ -207,7 +224,7 @@ You can dynamically update the selected country on the component using `updateSe
 ```javascript
     //updateSelected Method
     this.refs.userFlag.updateSelected("UK")
-    
+
     //component render
     <ReactFlagsSelect
     ref="userFlag"
@@ -215,13 +232,12 @@ You can dynamically update the selected country on the component using `updateSe
 ```
 
 ## License
+
 MIT Licensed. Copyright (c) Richard Ekwonye 2017.
 
 [build-badge]: https://img.shields.io/travis/ekwonye-richard/react-flags-select/master.svg?style=flat-square
 [build]: https://travis-ci.org/ekwonye-richard/react-flags-select
-
 [npm-badge]: https://img.shields.io/npm/v/react-flags-select.svg?style=flat-square
 [npm]: https://www.npmjs.org/package/react-flags-select
-
 [coveralls-badge]: https://img.shields.io/coveralls/ekwonye-richard/react-flags-select/master.svg?style=flat-square
 [coveralls]: https://coveralls.io/github/ekwonye-richard/react-flags-select

--- a/README.md
+++ b/README.md
@@ -183,18 +183,6 @@ You can disable the options dropdown, however the selected country can be update
     disabled={true} />
 ```
 
-### Show Arrow
-
-You can hide or show the down arrow. The default value is true.
-
-```javascript
-<ReactFlagsSelect
-  defaultCountry="US"
-  showSelectedLabel={false}
-  showArrow={false}
-/>
-```
-
 ### onSelect
 
 You can use onSelect event handler which fires each time an option is selected.

--- a/README.md
+++ b/README.md
@@ -7,33 +7,30 @@
 A customizable svg flags select components for React Js.
 
 ## Demo and Example
-
 Live demo: [ekwonye-richard.github.io/react-flags-select/](https://ekwonye-richard.github.io/react-flags-select/)
 
 ## Installation
-
 The package can be installed via NPM:
-
 ```
 npm install react-flags-select --save
 ```
-
 react-flags-select can be imported as follows
 
 ```javascript
-import ReactFlagsSelect from "react-flags-select";
+import ReactFlagsSelect from 'react-flags-select';
 
 //import css module
-import "react-flags-select/css/react-flags-select.css";
+import 'react-flags-select/css/react-flags-select.css';
 
 //OR import sass module
-import "react-flags-select/scss/react-flags-select.scss";
+import 'react-flags-select/scss/react-flags-select.scss';
+
 ```
 
 ## Usage
 
 ```javascript
-<ReactFlagsSelect />
+    <ReactFlagsSelect />
 ```
 
 All country Codes: [Country Codes](https://github.com/ekwonye-richard/react-flags-select/blob/master/src/countries.js)
@@ -43,7 +40,8 @@ All country Codes: [Country Codes](https://github.com/ekwonye-richard/react-flag
 You can select a default country to be rendered.
 
 ```javascript
-<ReactFlagsSelect defaultCountry="US" />
+    <ReactFlagsSelect
+    defaultCountry="US" />
 ```
 
 ### Searchable
@@ -51,7 +49,8 @@ You can select a default country to be rendered.
 You can enable search filter using prop `searchable`.
 
 ```javascript
-<ReactFlagsSelect searchable={true} />
+    <ReactFlagsSelect
+    searchable={true} />
 ```
 
 ### Search Placeholder
@@ -59,24 +58,26 @@ You can enable search filter using prop `searchable`.
 You can set the placeholder text for search using prop `searchPlaceholder`.
 
 ```javascript
-<ReactFlagsSelect searchable={true} searchPlaceholder="Search for a country" />
+    <ReactFlagsSelect
+    searchable={true}
+    searchPlaceholder="Search for a country" />
 ```
+
 
 ### Countries
 
 You can use an array of countries rather than the full list of countries.
 
 ```javascript
-<ReactFlagsSelect countries={["US", "GB", "FR", "DE", "IT", "NG"]} />
+    <ReactFlagsSelect
+    countries={["US", "GB", "FR", "DE", "IT", "NG"]} />
 ```
-
 or create a black list of countries
 
 ```javascript
-<ReactFlagsSelect
-  countries={["US", "GB", "FR", "DE", "IT", "NG"]}
-  blackList={true}
-/>
+    <ReactFlagsSelect
+    countries={["US", "GB", "FR", "DE", "IT", "NG"]}
+    blackList={true} />
 ```
 
 ### Custom Labels
@@ -84,10 +85,9 @@ or create a black list of countries
 You can use an object of countries labels to replace the countries name. The default country name for a country will be used when the country code has no label passed.
 
 ```javascript
-<ReactFlagsSelect
-  countries={["US", "GB", "FR", "DE", "IT"]}
-  customLabels={{ US: "EN-US", GB: "EN-GB", FR: "FR", DE: "DE", IT: "IT" }}
-/>
+    <ReactFlagsSelect
+    countries={["US", "GB", "FR","DE","IT"]}
+    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}} />
 ```
 
 ### Placeholder
@@ -95,11 +95,10 @@ You can use an object of countries labels to replace the countries name. The def
 You can replace the default placeholder text.
 
 ```javascript
-<ReactFlagsSelect
-  countries={["US", "GB", "FR", "DE", "IT"]}
-  customLabels={{ US: "EN-US", GB: "EN-GB", FR: "FR", DE: "DE", IT: "IT" }}
-  placeholder="Select Language"
-/>
+    <ReactFlagsSelect
+    countries={["US", "GB", "FR","DE","IT"]}
+    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
+    placeholder="Select Language" />
 ```
 
 ### Show Selected Label
@@ -107,12 +106,11 @@ You can replace the default placeholder text.
 You can hide or show the label of a selected flag. The default value is true.
 
 ```javascript
-<ReactFlagsSelect
-  countries={["US", "GB", "FR", "DE", "IT"]}
-  customLabels={{ US: "EN-US", GB: "EN-GB", FR: "FR", DE: "DE", IT: "IT" }}
-  placeholder="Select Language"
-  showSelectedLabel={false}
-/>
+    <ReactFlagsSelect
+    countries={["US", "GB", "FR","DE","IT"]}
+    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
+    placeholder="Select Language"
+    showSelectedLabel={false} />
 ```
 
 ### Show Option Label
@@ -120,13 +118,12 @@ You can hide or show the label of a selected flag. The default value is true.
 You can hide or show the label of the flags in the options dropdown. The default value is true.
 
 ```javascript
-<ReactFlagsSelect
-  countries={["US", "GB", "FR", "DE", "IT"]}
-  customLabels={{ US: "EN-US", GB: "EN-GB", FR: "FR", DE: "DE", IT: "IT" }}
-  placeholder="Select Language"
-  showSelectedLabel={false}
-  showOptionLabel={false}
-/>
+    <ReactFlagsSelect
+    countries={["US", "GB", "FR","DE","IT"]}
+    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
+    placeholder="Select Language"
+    showSelectedLabel={false}
+    showOptionLabel={false} />
 ```
 
 ### Selected Size
@@ -134,30 +131,27 @@ You can hide or show the label of the flags in the options dropdown. The default
 You can set the size in pixels for the svg flag and label of the selected option.
 
 ```javascript
-<ReactFlagsSelect
-  countries={["US", "GB", "FR", "DE", "IT"]}
-  customLabels={{ US: "EN-US", GB: "EN-GB", FR: "FR", DE: "DE", IT: "IT" }}
-  placeholder="Select Language"
-  showSelectedLabel={false}
-  showOptionLabel={false}
-  selectedSize={14}
-/>
+    <ReactFlagsSelect
+    countries={["US", "GB", "FR","DE","IT"]}
+    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
+    placeholder="Select Language"
+    showSelectedLabel={false}
+    showOptionLabel={false}
+    selectedSize={14} />
 ```
 
 ### Options Size
 
 You can set the size in pixels for the svg flags and labels in the options dropdown.
-
 ```javascript
-<ReactFlagsSelect
-  countries={["US", "GB", "FR", "DE", "IT"]}
-  customLabels={{ US: "EN-US", GB: "EN-GB", FR: "FR", DE: "DE", IT: "IT" }}
-  placeholder="Select Language"
-  showSelectedLabel={false}
-  showOptionLabel={false}
-  selectedSize={18}
-  optionsSize={14}
-/>
+    <ReactFlagsSelect
+    countries={["US", "GB", "FR","DE","IT"]}
+    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
+    placeholder="Select Language"
+    showSelectedLabel={false}
+    showOptionLabel={false}
+    selectedSize={18}
+    optionsSize={14} />
 ```
 
 ### className
@@ -165,15 +159,17 @@ You can set the size in pixels for the svg flags and labels in the options dropd
 You can pass a style className that will be attached to the top-level `div` of the component.
 
 ```javascript
-<ReactFlagsSelect className="menu-flags" />
+    <ReactFlagsSelect
+    className="menu-flags" />
 ```
 
 ### Align Options
 
-You can align the options dropdown to either left or right. The default value is right.
+You can align the options dropdown to  either left or right. The default value is right.
 
 ```javascript
-<ReactFlagsSelect alignOptions="left" />
+    <ReactFlagsSelect
+    alignOptions="left" />
 ```
 
 ### Disabled
@@ -181,11 +177,10 @@ You can align the options dropdown to either left or right. The default value is
 You can disable the options dropdown, however the selected country can be updated using the `updateSelected()` method. This can be used for flag badges.
 
 ```javascript
-<ReactFlagsSelect
-  defaultCountry="US"
-  showSelectedLabel={false}
-  disabled={true}
-/>
+    <ReactFlagsSelect
+    defaultCountry="US"
+    showSelectedLabel={false}
+    disabled={true} />
 ```
 
 ### Show Arrow
@@ -210,7 +205,7 @@ You can use onSelect event handler which fires each time an option is selected.
     onSelectFlag(countryCode){
         console.log(countryCode)
     }
-
+    
     //component render
     <ReactFlagsSelect
     defaultCountry="US"
@@ -224,7 +219,7 @@ You can dynamically update the selected country on the component using `updateSe
 ```javascript
     //updateSelected Method
     this.refs.userFlag.updateSelected("UK")
-
+    
     //component render
     <ReactFlagsSelect
     ref="userFlag"
@@ -232,12 +227,13 @@ You can dynamically update the selected country on the component using `updateSe
 ```
 
 ## License
-
 MIT Licensed. Copyright (c) Richard Ekwonye 2017.
 
 [build-badge]: https://img.shields.io/travis/ekwonye-richard/react-flags-select/master.svg?style=flat-square
 [build]: https://travis-ci.org/ekwonye-richard/react-flags-select
+
 [npm-badge]: https://img.shields.io/npm/v/react-flags-select.svg?style=flat-square
 [npm]: https://www.npmjs.org/package/react-flags-select
+
 [coveralls-badge]: https://img.shields.io/coveralls/ekwonye-richard/react-flags-select/master.svg?style=flat-square
 [coveralls]: https://coveralls.io/github/ekwonye-richard/react-flags-select

--- a/README.md
+++ b/README.md
@@ -211,28 +211,6 @@ You can use onSelect event handler which fires each time an option is selected.
     onSelect={this.onSelectFlag} />
 ```
 
-### customFilter
-
-You can use customFilter to filter the search results. You must return an array of the filtered country codes.
-`customFilter(searchValue, countryList, defaultLabels, customLabels)`.
-
-```javascript
-    //customFilter Method
-    customFilter(searchValue, countryList, defaultLabels, customLabels){
-        const filteredList = countryList.filter(country => {
-            // filter logic here
-            return true
-        });
-        return filteredList;
-    }
-    
-    //component render
-    <ReactFlagsSelect
-    defaultCountry="US"
-    customFilter={this.customFilter} />
-```
-
-
 ### updateSelected
 
 You can dynamically update the selected country on the component using `updateSelected()` method.

--- a/README.md
+++ b/README.md
@@ -183,6 +183,17 @@ You can disable the options dropdown, however the selected country can be update
     disabled={true} />
 ```
 
+### Show Arrow
+
+You can hide or show the down arrow. The default value is true.
+
+```javascript
+    <ReactFlagsSelect
+    defaultCountry="US"
+    showSelectedLabel={false}
+    showArrow={true} />
+```
+
 ### onSelect
 
 You can use onSelect event handler which fires each time an option is selected.

--- a/lib/index.js
+++ b/lib/index.js
@@ -191,7 +191,7 @@ var ReactFlagsSelect = function (_Component) {
 				),
 				_react2.default.createElement(
 					'span',
-					{ className: 'arrow-down ' + ((this.props.disabled || !this.props.showArrow) ? 'hidden' : '') },
+					{ className: 'arrow-down ' + (this.props.disabled ? 'hidden' : '') },
 					'\u25BE'
 				)
 			),
@@ -239,7 +239,6 @@ ReactFlagsSelect.defaultProps = {
 	alignOptions: "right",
 	customLabels: {},
 	disabled: false,
-	showArrow: true,
 	blackList: false,
 	searchable: false,
 	searchPlaceholder: 'Search'
@@ -259,7 +258,6 @@ ReactFlagsSelect.propTypes = process.env.NODE_ENV !== "production" ? {
 	alignOptions: _propTypes2.default.string,
 	onSelect: _propTypes2.default.func,
 	disabled: _propTypes2.default.bool,
-	showArrow: _propTypes2.default.bool,
 	searchable: _propTypes2.default.bool,
 	searchPlaceholder: _propTypes2.default.string
 } : {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,13 +2,13 @@
 
 exports.__esModule = true;
 
-var _propTypes = require('prop-types');
-
-var _propTypes2 = _interopRequireDefault(_propTypes);
-
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var _countries = require('./countries');
 
@@ -105,15 +105,10 @@ var ReactFlagsSelect = function (_Component) {
 		var _this2 = this;
 
 		var filterValue = evt.target.value;
-		var filteredCountries = void 0;
-		if (typeof this.props.customFilter === 'function') {
-			filteredCountries = this.props.customFilter(filterValue);
-		} else {
-			filteredCountries = filterValue && this.state.countries.filter(function (key) {
-				var label = _this2.props.customLabels[key] || _countries2.default[key];
-				return label && label.match(new RegExp(filterValue, 'i'));
-			});
-		}
+		var filteredCountries = filterValue && this.state.countries.filter(function (key) {
+			var label = _this2.props.customLabels[key] || _countries2.default[key];
+			return label && label.match(new RegExp(filterValue, 'i'));
+		});
 
 		this.setState({ filter: filterValue, filteredCountries: filteredCountries });
 	};
@@ -196,7 +191,7 @@ var ReactFlagsSelect = function (_Component) {
 				),
 				_react2.default.createElement(
 					'span',
-					{ className: 'arrow-down ' + (this.props.disabled ? 'hidden' : '') },
+					{ className: 'arrow-down ' + ((this.props.disabled || !this.props.showArrow) ? 'hidden' : '') },
 					'\u25BE'
 				)
 			),
@@ -244,6 +239,7 @@ ReactFlagsSelect.defaultProps = {
 	alignOptions: "right",
 	customLabels: {},
 	disabled: false,
+	showArrow: true,
 	blackList: false,
 	searchable: false,
 	searchPlaceholder: 'Search'
@@ -262,8 +258,8 @@ ReactFlagsSelect.propTypes = process.env.NODE_ENV !== "production" ? {
 	showOptionLabel: _propTypes2.default.bool,
 	alignOptions: _propTypes2.default.string,
 	onSelect: _propTypes2.default.func,
-	customFilter: _propTypes2.default.func,
 	disabled: _propTypes2.default.bool,
+	showArrow: _propTypes2.default.bool,
 	searchable: _propTypes2.default.bool,
 	searchPlaceholder: _propTypes2.default.string
 } : {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,15 +105,10 @@ var ReactFlagsSelect = function (_Component) {
 		var _this2 = this;
 
 		var filterValue = evt.target.value;
-		var filteredCountries = void 0;
-		if (typeof this.props.customFilter === 'function') {
-			filteredCountries = _this2.props.customFilter(filterValue, this.state.countries, _countries, _this2.props.customLabels);
-		} else {
-			filteredCountries = filterValue && this.state.countries.filter(function (key) {
-				var label = _this2.props.customLabels[key] || _countries2.default[key];
-				return label && label.match(new RegExp(filterValue, 'i'));
-			});
-		}
+		var filteredCountries = filterValue && this.state.countries.filter(function (key) {
+			var label = _this2.props.customLabels[key] || _countries2.default[key];
+			return label && label.match(new RegExp(filterValue, 'i'));
+		});
 
 		this.setState({ filter: filterValue, filteredCountries: filteredCountries });
 	};

--- a/lib/index.js
+++ b/lib/index.js
@@ -191,7 +191,7 @@ var ReactFlagsSelect = function (_Component) {
 				),
 				_react2.default.createElement(
 					'span',
-					{ className: 'arrow-down ' + (this.props.disabled ? 'hidden' : '') },
+					{ className: 'arrow-down ' + ((this.props.disabled || !this.props.showArrow) ? 'hidden' : '') },
 					'\u25BE'
 				)
 			),
@@ -239,6 +239,7 @@ ReactFlagsSelect.defaultProps = {
 	alignOptions: "right",
 	customLabels: {},
 	disabled: false,
+	showArrow: true,
 	blackList: false,
 	searchable: false,
 	searchPlaceholder: 'Search'
@@ -258,6 +259,7 @@ ReactFlagsSelect.propTypes = process.env.NODE_ENV !== "production" ? {
 	alignOptions: _propTypes2.default.string,
 	onSelect: _propTypes2.default.func,
 	disabled: _propTypes2.default.bool,
+	showArrow: _propTypes2.default.bool,
 	searchable: _propTypes2.default.bool,
 	searchPlaceholder: _propTypes2.default.string
 } : {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,13 +2,13 @@
 
 exports.__esModule = true;
 
-var _react = require('react');
-
-var _react2 = _interopRequireDefault(_react);
-
 var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
 
 var _countries = require('./countries');
 
@@ -105,10 +105,15 @@ var ReactFlagsSelect = function (_Component) {
 		var _this2 = this;
 
 		var filterValue = evt.target.value;
-		var filteredCountries = filterValue && this.state.countries.filter(function (key) {
-			var label = _this2.props.customLabels[key] || _countries2.default[key];
-			return label && label.match(new RegExp(filterValue, 'i'));
-		});
+		var filteredCountries = void 0;
+		if (typeof this.props.customFilter === 'function') {
+			filteredCountries = this.props.customFilter(filterValue);
+		} else {
+			filteredCountries = filterValue && this.state.countries.filter(function (key) {
+				var label = _this2.props.customLabels[key] || _countries2.default[key];
+				return label && label.match(new RegExp(filterValue, 'i'));
+			});
+		}
 
 		this.setState({ filter: filterValue, filteredCountries: filteredCountries });
 	};
@@ -257,6 +262,7 @@ ReactFlagsSelect.propTypes = process.env.NODE_ENV !== "production" ? {
 	showOptionLabel: _propTypes2.default.bool,
 	alignOptions: _propTypes2.default.string,
 	onSelect: _propTypes2.default.func,
+	customFilter: _propTypes2.default.func,
 	disabled: _propTypes2.default.bool,
 	searchable: _propTypes2.default.bool,
 	searchPlaceholder: _propTypes2.default.string

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import PropTypes from 'prop-types'
 import countries from './countries';
 
 class ReactFlagsSelect extends Component {
@@ -78,11 +78,16 @@ class ReactFlagsSelect extends Component {
 	}
 
 	filterSearch(evt) {
-		let filterValue = evt.target.value;
-		let filteredCountries = filterValue && this.state.countries.filter(key => {
-			let label = this.props.customLabels[key] || countries[key];
-			return  label && label.match(new RegExp(filterValue, 'i'))
-		}) ;
+    let filterValue = evt.target.value;
+    let filteredCountries
+    if(typeof this.props.customFilter === 'function') {
+      filteredCountries = this.props.customFilter(filterValue)
+    } else {
+      filteredCountries = filterValue && this.state.countries.filter(key => {
+        let label = this.props.customLabels[key] || countries[key];
+        return  label && label.match(new RegExp(filterValue, 'i'))
+      }) ;
+    }
 
 		this.setState({filter : filterValue, filteredCountries : filteredCountries });
 	}
@@ -206,6 +211,7 @@ ReactFlagsSelect.propTypes = {
 	showOptionLabel: PropTypes.bool,
 	alignOptions: PropTypes.string,
 	onSelect: PropTypes.func,
+	customFilter: PropTypes.func,
 	disabled: PropTypes.bool,
 	searchable: PropTypes.bool,
 	searchPlaceholder: PropTypes.string,

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import PropTypes from 'prop-types'
 import countries from './countries';
 
 class ReactFlagsSelect extends Component {
@@ -151,7 +151,7 @@ class ReactFlagsSelect extends Component {
 					{!isSelected &&
 						<span className="country-label">{this.props.placeholder}</span>
 					}
-					<span className={`arrow-down ${this.props.disabled ? 'hidden' : ''}`}>▾</span>
+					<span className={`arrow-down ${(this.props.disabled || !this.props.showArrow) ? 'hidden' : ''}`}>▾</span>
 				</div>
 
 				{this.state.openOptions &&
@@ -188,6 +188,7 @@ ReactFlagsSelect.defaultProps = {
 	alignOptions: "right",
 	customLabels: {},
 	disabled: false,
+	showArrow: true,
 	blackList: false,
 	searchable: false,
 	searchPlaceholder: 'Search',
@@ -207,6 +208,7 @@ ReactFlagsSelect.propTypes = {
 	alignOptions: PropTypes.string,
 	onSelect: PropTypes.func,
 	disabled: PropTypes.bool,
+	showArrow: PropTypes.bool,
 	searchable: PropTypes.bool,
 	searchPlaceholder: PropTypes.string,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -78,16 +78,11 @@ class ReactFlagsSelect extends Component {
 	}
 
 	filterSearch(evt) {
-    let filterValue = evt.target.value;
-    let filteredCountries
-    if(typeof this.props.customFilter === 'function') {
-      filteredCountries = this.props.customFilter(filterValue, this.state.countries, countries, this.props.customLabels)
-    } else {
-      filteredCountries = filterValue && this.state.countries.filter(key => {
-        let label = this.props.customLabels[key] || countries[key];
-        return  label && label.match(new RegExp(filterValue, 'i'))
-      }) ;
-    }
+		let filterValue = evt.target.value;
+		let filteredCountries = filterValue && this.state.countries.filter(key => {
+			let label = this.props.customLabels[key] || countries[key];
+			return  label && label.match(new RegExp(filterValue, 'i'))
+		}) ;
 
 		this.setState({filter : filterValue, filteredCountries : filteredCountries });
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -78,16 +78,11 @@ class ReactFlagsSelect extends Component {
 	}
 
 	filterSearch(evt) {
-    let filterValue = evt.target.value;
-    let filteredCountries
-    if(typeof this.props.customFilter === 'function') {
-      filteredCountries = this.props.customFilter(filterValue)
-    } else {
-      filteredCountries = filterValue && this.state.countries.filter(key => {
-        let label = this.props.customLabels[key] || countries[key];
-        return  label && label.match(new RegExp(filterValue, 'i'))
-      }) ;
-    }
+		let filterValue = evt.target.value;
+		let filteredCountries = filterValue && this.state.countries.filter(key => {
+			let label = this.props.customLabels[key] || countries[key];
+			return  label && label.match(new RegExp(filterValue, 'i'))
+		}) ;
 
 		this.setState({filter : filterValue, filteredCountries : filteredCountries });
 	}
@@ -156,7 +151,7 @@ class ReactFlagsSelect extends Component {
 					{!isSelected &&
 						<span className="country-label">{this.props.placeholder}</span>
 					}
-					<span className={`arrow-down ${this.props.disabled ? 'hidden' : ''}`}>▾</span>
+					<span className={`arrow-down ${(this.props.disabled || !this.props.showArrow) ? 'hidden' : ''}`}>▾</span>
 				</div>
 
 				{this.state.openOptions &&
@@ -193,6 +188,7 @@ ReactFlagsSelect.defaultProps = {
 	alignOptions: "right",
 	customLabels: {},
 	disabled: false,
+	showArrow: true,
 	blackList: false,
 	searchable: false,
 	searchPlaceholder: 'Search',
@@ -211,8 +207,8 @@ ReactFlagsSelect.propTypes = {
 	showOptionLabel: PropTypes.bool,
 	alignOptions: PropTypes.string,
 	onSelect: PropTypes.func,
-	customFilter: PropTypes.func,
 	disabled: PropTypes.bool,
+	showArrow: PropTypes.bool,
 	searchable: PropTypes.bool,
 	searchPlaceholder: PropTypes.string,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types'
 import countries from './countries';
 
 class ReactFlagsSelect extends Component {
@@ -151,7 +151,7 @@ class ReactFlagsSelect extends Component {
 					{!isSelected &&
 						<span className="country-label">{this.props.placeholder}</span>
 					}
-					<span className={`arrow-down ${(this.props.disabled || !this.props.showArrow) ? 'hidden' : ''}`}>▾</span>
+					<span className={`arrow-down ${this.props.disabled ? 'hidden' : ''}`}>▾</span>
 				</div>
 
 				{this.state.openOptions &&
@@ -188,7 +188,6 @@ ReactFlagsSelect.defaultProps = {
 	alignOptions: "right",
 	customLabels: {},
 	disabled: false,
-	showArrow: true,
 	blackList: false,
 	searchable: false,
 	searchPlaceholder: 'Search',
@@ -208,7 +207,6 @@ ReactFlagsSelect.propTypes = {
 	alignOptions: PropTypes.string,
 	onSelect: PropTypes.func,
 	disabled: PropTypes.bool,
-	showArrow: PropTypes.bool,
 	searchable: PropTypes.bool,
 	searchPlaceholder: PropTypes.string,
 }


### PR DESCRIPTION
There wasn't an option to hide the down arrow ▾, so I added an optional prop.

`showArrow` defaults to `true`

This is the same as #28. I recreated the PR because I created a new branch.