### PR TITLE
Change country name of 'TW' to 'Taiwan'

### DIFF
--- a/lib/countries.js
+++ b/lib/countries.js
@@ -195,7 +195,7 @@ exports.default = {
     "SE": "Sweden",
     "CH": "Switzerland",
     "SY": "Syria",
-    "TW": "Taiwan, Province of China",
+    "TW": "Taiwan",
     "TJ": "Tajikistan",
     "TZ": "Tanzania",
     "TH": "Thailand",

--- a/src/countries.js
+++ b/src/countries.js
@@ -192,7 +192,7 @@ export default ({
     "SE": "Sweden",
     "CH": "Switzerland",
     "SY": "Syria",
-    "TW": "Taiwan, Province of China",
+    "TW": "Taiwan",
     "TJ": "Tajikistan",
     "TZ": "Tanzania",
     "TH": "Thailand",


### PR DESCRIPTION
Simply "Taiwan" is a more accurate and commonly accepted name of the island nation where 23 million Taiwanese people live.

"Taiwan, Province of China" has a common connotation that Taiwan is a part of the People's Republic of China, which would be misleading, untrue, and offensive to the people of the proudly democratic Taiwan. Taiwan holds its elections for president every four years, holds its own standing army, issues its own currency, and has never been ruled by the Chinese Communist Party.

The current treatment in ReactFlagsSelect places the flag of Taiwan (Republic of China) next to the title "Taiwan, Province of China". To be clear, this is technically aligned with the official stance of the Republic of China, aka the government that rules Taiwan, which is led by the aforementioned president who is elected every four years. The reasons are historical: the ROC once ruled mainland China in the first half of the 1900's, and in 1949 relocated the government to Taiwan and no longer rules the mainland, but never constitutionally renounced sovereignty claims over the mainland. Thus, officially, according to the ROC constitution, Taiwan _is_ a province of China, but using a different definition of China from that of the PRC.

However, Taiwan has been de facto a sovereign state since 1949, and a growing portion of the population ([currently 28%](https://www.taipeitimes.com/News/editorials/archives/2020/07/14/2003739870)) now believes in the need the pursue de jure soverignty. 

As you can see, this history is complex and not common knowledge to the average English speaker of the world. To most users, "Taiwan, Province of China" would be unconsciously registered as "evidence" that Taiwan is a part of China, something that the people of Taiwan find incredibly offensive and not how they want to be known internationally. Taiwan must be treated as a totally separate state from China in ReactFlagsSelect and country lists in general.