### PR TITLE
Allows showing multiple times the same country (Closes #61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,16 @@ You can use an object of countries labels to replace the countries name. The def
 
 ```javascript
     <ReactFlagsSelect
-    countries={["US", "GB", "FR","DE","IT"]}
-    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}} />
+    countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]} />
+```
+
+### Custom Labels with multiple times the same country
+
+You can also show multiple times the same country but with a different label.
+
+```javascript
+    <ReactFlagsSelect
+    countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"BE": "FR"}, {"BE": "NL"}, {"IT": "IT"}]} />
 ```
 
 ### Placeholder
@@ -96,8 +104,7 @@ You can replace the default placeholder text.
 
 ```javascript
     <ReactFlagsSelect
-    countries={["US", "GB", "FR","DE","IT"]}
-    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
+    countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]}
     placeholder="Select Language" />
 ```
 
@@ -107,8 +114,7 @@ You can hide or show the label of a selected flag. The default value is true.
 
 ```javascript
     <ReactFlagsSelect
-    countries={["US", "GB", "FR","DE","IT"]}
-    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
+    countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]}
     placeholder="Select Language"
     showSelectedLabel={false} />
 ```
@@ -119,8 +125,7 @@ You can hide or show the label of the flags in the options dropdown. The default
 
 ```javascript
     <ReactFlagsSelect
-    countries={["US", "GB", "FR","DE","IT"]}
-    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
+    countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]}
     placeholder="Select Language"
     showSelectedLabel={false}
     showOptionLabel={false} />
@@ -132,8 +137,7 @@ You can set the size in pixels for the svg flag and label of the selected option
 
 ```javascript
     <ReactFlagsSelect
-    countries={["US", "GB", "FR","DE","IT"]}
-    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
+    countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]}
     placeholder="Select Language"
     showSelectedLabel={false}
     showOptionLabel={false}
@@ -145,8 +149,7 @@ You can set the size in pixels for the svg flag and label of the selected option
 You can set the size in pixels for the svg flags and labels in the options dropdown.
 ```javascript
     <ReactFlagsSelect
-    countries={["US", "GB", "FR","DE","IT"]}
-    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
+    countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]}
     placeholder="Select Language"
     showSelectedLabel={false}
     showOptionLabel={false}

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -17,7 +17,7 @@ class Demo extends React.Component {
 				<div className="main">
 					<p className="info">A customizable svg flags select components for React Js.</p>
 					<div className="section-header">
-						<span>Examples</span> 
+						<span>Examples</span>
 					</div>
 					<hr />
 					<div className="demo-group">
@@ -88,22 +88,32 @@ class Demo extends React.Component {
 							<span>Custom Labels</span>
 						</div>
 						<div className="demo-source">
-							<Highlight lang={'js'} value={'<ReactFlagsSelect \n countries={["US", "GB", "FR", "DE", "IT"]} \n customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}} />'} />
+							<Highlight lang={'js'} value={'<ReactFlagsSelect \n countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]} />'} />
 						</div>
 						<ReactFlagsSelect
-					    countries={["US", "GB", "FR", "DE", "IT"]} 
-					    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}} />
+					    countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]} />
 					</div>
+
+					<div className="demo-group">
+						<div className="demo-group-title">
+							<span>Custom Labels with multiple times the same country</span>
+						</div>
+						<div className="demo-source">
+							<Highlight lang={'js'} value={'<ReactFlagsSelect \n countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"BE": "FR"}, {"BE": "NL"}, {"IT": "IT"}]} />'} />
+						</div>
+						<ReactFlagsSelect
+					    countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"BE": "FR"}, {"BE": "NL"}, {"IT": "IT"}]} />
+					</div>
+
 					<div className="demo-group">
 						<div className="demo-group-title">
 							<span>Placeholder</span>
 						</div>
 						<div className="demo-source">
-							<Highlight lang={'js'} value={'<ReactFlagsSelect \n countries={["US", "GB", "FR", "DE", "IT"]} \n customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}} \n placeholder="Select Language" />'} />
+							<Highlight lang={'js'} value={'<ReactFlagsSelect \n countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]} \n placeholder="Select Language" />'} />
 						</div>
 						<ReactFlagsSelect
-					    countries={["US", "GB", "FR", "DE", "IT"]} 
-					    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
+					    countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]}
 					    placeholder="Select Language" />
 					</div>
 					<div className="demo-group">
@@ -111,11 +121,10 @@ class Demo extends React.Component {
 							<span>Show Selected Label</span>
 						</div>
 						<div className="demo-source">
-							<Highlight lang={'js'} value={'<ReactFlagsSelect \n countries={["US", "GB", "FR", "DE", "IT"]} \n customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}} \n placeholder="Select Language" \n showSelectedLabel={false} />'} />
+							<Highlight lang={'js'} value={'<ReactFlagsSelect \n countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]} \n placeholder="Select Language" \n showSelectedLabel={false} />'} />
 						</div>
 						<ReactFlagsSelect
-					    countries={["US", "GB", "FR", "DE", "IT"]} 
-					    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
+					    countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]}
 					    placeholder="Select Language"
 					    showSelectedLabel={false} />
 					</div>
@@ -124,11 +133,10 @@ class Demo extends React.Component {
 							<span>Show Option Label</span>
 						</div>
 						<div className="demo-source">
-							<Highlight lang={'js'} value={'<ReactFlagsSelect \n countries={["US", "GB", "FR", "DE", "IT"]} \n customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}} \n placeholder="Select Language" \n showSelectedLabel={false} \n showOptionLabel={false} />'} />
+							<Highlight lang={'js'} value={'<ReactFlagsSelect \n countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]} \n placeholder="Select Language" \n showSelectedLabel={false} \n showOptionLabel={false} />'} />
 						</div>
 						<ReactFlagsSelect
-					    countries={["US", "GB", "FR", "DE", "IT"]} 
-					    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
+					    countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]}
 					    placeholder="Select Language"
 					    showSelectedLabel={false}
 					    showOptionLabel={false} />
@@ -138,11 +146,10 @@ class Demo extends React.Component {
 							<span>Selected Size</span>
 						</div>
 						<div className="demo-source">
-							<Highlight lang={'js'} value={'<ReactFlagsSelect \n countries={["US", "GB", "FR", "DE", "IT"]} \n customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}} \n placeholder="Select Language" \n showSelectedLabel={false} \n showOptionLabel={false} \n selectedSize={14} />'} />
+							<Highlight lang={'js'} value={'<ReactFlagsSelect \n countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]} \n placeholder="Select Language" \n showSelectedLabel={false} \n showOptionLabel={false} \n selectedSize={14} />'} />
 						</div>
 						<ReactFlagsSelect
-					    countries={["US", "GB", "FR", "DE", "IT"]} 
-					    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
+					    countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]}
 					    placeholder="Select Language"
 					    showSelectedLabel={false}
 					    showOptionLabel={false}
@@ -153,11 +160,10 @@ class Demo extends React.Component {
 							<span>Options Size</span>
 						</div>
 						<div className="demo-source">
-							<Highlight lang={'js'} value={'<ReactFlagsSelect \n countries={["US", "GB", "FR", "DE", "IT"]} \n customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}} \n placeholder="Select Language" \n showSelectedLabel={false} \n showOptionLabel={false} \n selectedSize={14} \n optionsSize={14} />'} />
+							<Highlight lang={'js'} value={'<ReactFlagsSelect \n countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]} \n placeholder="Select Language" \n showSelectedLabel={false} \n showOptionLabel={false} \n selectedSize={14} \n optionsSize={14} />'} />
 						</div>
 						<ReactFlagsSelect
-					    countries={["US", "GB", "FR", "DE", "IT"]} 
-					    customLabels={{"US": "EN-US","GB": "EN-GB","FR": "FR","DE": "DE","IT": "IT"}}
+					    countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"DE": "DE"}, {"IT": "IT"}]}
 					    placeholder="Select Language"
 					    showSelectedLabel={false}
 					    showOptionLabel={false}

--- a/src/countries.js
+++ b/src/countries.js
@@ -14,7 +14,7 @@ export default ({
     "AT": "Austria",
     "AZ": "Azerbaijan",
     "BS": "Bahamas",
-    "BH": "Bahrain", 
+    "BH": "Bahrain",
     "BD": "Bangladesh",
     "BB": "Barbados",
     "BY": "Belarus",


### PR DESCRIPTION
This PR allows to show multiple times the same country flag but with a different label (a use case is French in Belgium and Dutch in Belgium) and it also removes the `customLabels` property, which was doing some redundancy with `countries`, and reworks the way `countries` is managed.

This PR also updates the `README.md` file in order to show case showing multiple times the same country. It also updates the `demo` source file.

## `customLabels` deletion

**BREAKING CHANGE**

It was much more simple to transform the `countries` array of string in an array of object in order to pass the custom labels for each countries, but this PR supports both formats so that you can still do:

```javascript
<ReactFlagsSelect
  countries={["US", "GB", "FR","DE","IT"]}
/>
```

And now you can also do:

```javascript
<ReactFlagsSelect
  countries={[{"US": "EN-US"}, {"GB": "EN-GB"}, {"FR": "FR"}, {"BE": "FR"}, {"BE": "NL"}, {"IT": "IT"}]}
/>
```

I was thinking of implementing a deprecation warning mechanism in this library and deprecate the `customLabels` property, but I ended up not doing it for the following reason: Who reads browser's warnings? Instead, people using `customLabels` will got an error (so they'll look at it), and coming to this repo's `README.md` file, they will understand how to migrate.
A short description on how to migrate could be added to the to of the `README.md` file if you think this is too hard.

## Multiple times the same country

Basically before this PR, the state `selected` attribute was storing the country code, `BE` in my case. Now it stores the position in the `countries` array.

The `onSelect` and `onSelectWithKeyboard` functions have been updated in order to support both `countries` property format and now works like that:

* If the `countries` format is an array of strings, they are working the same was as before, they work and return the country code (`BE` in my case)
* If the `countries` format is an array of objects, they are working with the country code and the custom label (`BE_FR` in  my case)

Finally the `searchable` function has been adapted too in order to continue searching the `countries` list from the `countries.js` file when the `countries` property is an array of strings, but searches the custom label from the `countries` property when the `countries` property is an array of objects.

# The things I've tested

## `blackList`

This excludes the given entries to the `countries` properties and show a long list of flags.

## `defaultCountry`

The `defaultCountry` when not found is just not selecting an entry (I tried to set it to `GB` while it is not in the `countries` list), but when passing an existing value, it pre-selected it.

## `showSelectedLabel`

No big deal, show/hide the label as expected.

## `showOptionLabel`

No big deal, show/hide the label as expected.

## `onSelect`

I tried to use twice this library in the same page:

* One using an array of strings
* One using an array of objects

Both was binding the `onSelect` to a dedicated function showing a different `console.log`.

Im the first case I received `BE` or `FR` in my case, and in the second case I received `BE_FR`, `BR_NL`, and `FR_FR`.

## `searchable`

Searching `nl` showed only `BE_NL` entry, while searching `fr` showed `BE_FR` and `FR_FR` entries.