### PR TITLE
Fixed vertical alignment of flag

### DIFF
--- a/scss/react-flags-select.scss
+++ b/scss/react-flags-select.scss
@@ -98,7 +98,7 @@ $text-color: #4d4d4d;
       width: 1.3em;
       height: 1.3em;
       position: relative;
-      top: 0.3em;
+    
     }
   }
 


### PR DESCRIPTION
Simply remove the 0.3em. I am not sure why this was put there in the first place. Was there a specific reason for the 0.3em?

Cheers