### PR TITLE
chore: update ESM build config to allow tree-shaking

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (C) 2021 Richard Ekwonye
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,11 +2,13 @@
   "name": "react-flags-select",
   "version": "2.1.2",
   "description": "react-flags-select React component",
-  "main": "build/index.js",
-  "module": "build/index.esm.js",
+  "main": "build/cjs/index.js",
+  "module": "build/esm/index.js",
+  "types": "build/cjs/index.d.ts",
   "files": [
     "build"
   ],
+  "sideEffects": ["*.scss"],
   "scripts": {
     "lint": "yarn check-types && yarn lint:js",
     "check-types": "tsc --noEmit",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,9 +16,11 @@ export default {
       sourcemap: true,
     },
     {
-      file: pkg.module,
+      dir: pkg.module.replace(/index\.js$/, ""),
       format: "esm",
       sourcemap: true,
+      preserveModules: true,
+      preserveModulesRoot: "src",
     },
   ],
   plugins: [
@@ -29,7 +31,7 @@ export default {
       presets: ["@babel/env", "@babel/preset-react"],
     }),
     commonjs({ exclude: "/src/components/Flags/Af.js" }),
-    typescript({ useTsconfigDeclarationDir: false }),
+    typescript({ useTsconfigDeclarationDir: true }),
     postcss(),
   ],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
     "declaration": true,
+    "declarationDir": "build/cjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
This PR aims to enable tree shaking to take place. The problem described in #109 is that in its current state the whole library cannot be optimized fully and is bundled in production (about `850kB`), which is not desirable.

By updating some of the config values I managed to address this problem.

However please don't merge this PR immediately; we need to conduct a deeper review to ensure that it does not break existing things (and additionally the owner should give comments if they have a strong opinion about how things should be organized). Moreover I applied (a couple) further changes without testing them fully.