### PR TITLE
button id changeable for preventing non-unique id

### DIFF
--- a/src/components/ReactFlagsSelect/ReactFlagsSelect.tsx
+++ b/src/components/ReactFlagsSelect/ReactFlagsSelect.tsx
@@ -67,7 +67,7 @@ const ReactFlagsSelect: React.FC<Props> = ({
   blacklistCountries = false,
   fullWidth = true,
   disabled = false,
-  id,
+  id = "rfs",
 }) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
   const [countriesOptions, setCountriesOptions] = useState<CountryCodes>([]);
@@ -176,6 +176,8 @@ const ReactFlagsSelect: React.FC<Props> = ({
 
   const displayLabel = getLabel(validSelectedValue);
 
+  const btnId = `${id}-btn`;
+
   return (
     <div
       className={cx(styles.flagsSelect, className, {
@@ -186,7 +188,7 @@ const ReactFlagsSelect: React.FC<Props> = ({
     >
       <button
         ref={selectedFlagRef}
-        id="rfs-btn"
+        id={btnId}
         type="button"
         className={cx(styles.selectBtn, selectButtonClassName, {
           [styles.disabledBtn]: disabled,
@@ -195,10 +197,10 @@ const ReactFlagsSelect: React.FC<Props> = ({
         onClick={toggleDropdown}
         onKeyUp={(e) => closeDropdwownWithKeyboard(e)}
         disabled={disabled}
-        aria-labelledby="rfs-btn"
+        aria-labelledby={btnId}
         aria-haspopup="listbox"
         aria-expanded={isDropdownOpen}
-        data-testid="rfs-btn"
+        data-testid={btnId}
       >
         <span className={styles.selectValue}>
           {validSelectedValue ? (


### PR DESCRIPTION
This prevents the non-unique id alert when using more than one flag select

```
[DOM] Found 2 elements with non-unique id #rfs-btn: (More info: https://goo.gl/9p2vKq) <button id=​"rfs-btn" type=​"button" class=​"ReactFlagsSelect-module_selectBtn__19wW7 flag-select-button" aria-labelledby=​"rfs-btn" aria-haspopup=​"listbox" aria-expanded=​"false" data-testid=​"rfs-btn" style=​"font-size:​ 16px;​">​…​</button>​ flex 
```